### PR TITLE
Support for handling validation error while reading request entity

### DIFF
--- a/source/OpenAPI-Core.package/OAMediaTypeObject.class/instance/read.object..st
+++ b/source/OpenAPI-Core.package/OAMediaTypeObject.class/instance/read.object..st
@@ -1,3 +1,5 @@
 as yet unclassified
 read: value object: object
-	^ schema read: value object: object
+	^ [schema read: value object: object] on: JSONSchemaError do: [ :ex |
+			OAInvalidFormat signal: ex description
+		 ]


### PR DESCRIPTION
Now catch validation error and raise a dedicated OpenApi error.
The expected side effect is that the involved call will return an error response