### PR TITLE
Enable alphabetic order of parameters

### DIFF
--- a/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/operationObjectJSON.st
+++ b/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/operationObjectJSON.st
@@ -19,7 +19,7 @@ operationObjectJSON
 	{
       "name": "secondId",
       "in": "query",
-      "description": "just an ID to have more than one",
+      "description": "an ID to have more than one",
       "schema": {
         "type": "string"
       }

--- a/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/operationObjectJSON.st
+++ b/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/operationObjectJSON.st
@@ -15,6 +15,14 @@ operationObjectJSON
       "schema": {
         "type": "string"
       }
+    },
+	{
+      "name": "secondId",
+      "in": "query",
+      "description": "just an ID to have more than one",
+      "schema": {
+        "type": "string"
+      }
     }
   ],
   "requestBody": {

--- a/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/petStoreApiJsonString.st
+++ b/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/petStoreApiJsonString.st
@@ -113,7 +113,15 @@ petStoreApiJsonString
             "schema": {
               "type": "string"
             }
-          }
+          },
+			{
+      			"name": "secondId",
+      			"in": "query",
+      			"description": "just an ID to have more than one",
+      			"schema": {
+        		"type": "string"
+      		}
+    }
         ],
         "responses": {
           "200": {

--- a/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/testOpenAPISpecHasSortedParameters.st
+++ b/source/OpenAPI-Core-Tests.package/OAParsingTests.class/instance/testOpenAPISpecHasSortedParameters.st
@@ -1,0 +1,10 @@
+tests
+testOpenAPISpecHasSortedParameters
+	| api string json parameters |
+	api := OpenAPI fromString: self petStoreApiJsonString.
+	string := api specString.
+	json := NeoJSONObject fromString: string.
+	parameters := (json paths at: #'/pets/{petId}') get parameters.
+	self assert: parameters size equals: 2.
+	self assert: parameters first name equals: #petId.
+	self assert: parameters second name equals: #secondId

--- a/source/OpenAPI-Core.package/OAOperation.class/class/neoJsonMapping..st
+++ b/source/OpenAPI-Core.package/OAOperation.class/class/neoJsonMapping..st
@@ -4,7 +4,7 @@ neoJsonMapping: mapper
 		for: self
 		do: [ :mapping | 
 			mapping mapInstVars: #(tags summary description externalDocs operationId responses callbacks deprecated security servers).
-			(mapping mapInstVar: #parameters) valueSchema: #ParameterList.
+			(mapping mapAccessor: #parametersSortedByName mutator: #parameters: to: #parameters) valueSchema: #ParameterList.
 			(mapping mapInstVar: #requestBody) valueSchema: OARequestBody.
 			(mapping mapAccessor: #responses) valueSchema: #ResponsesDictionary. ].
 	mapper

--- a/source/OpenAPI-Core.package/OAOperation.class/instance/deprecated1..st
+++ b/source/OpenAPI-Core.package/OAOperation.class/instance/deprecated1..st
@@ -1,3 +1,0 @@
-accessing
-deprecated1: anObject
-	deprecated := anObject

--- a/source/OpenAPI-Core.package/OAOperation.class/instance/parametersSortedByName.st
+++ b/source/OpenAPI-Core.package/OAOperation.class/instance/parametersSortedByName.st
@@ -1,0 +1,4 @@
+accessing
+parametersSortedByName
+	parameters ifNil: [ ^ nil ].
+	^ parameters sorted: [ :a :b | a name < b name ]


### PR DESCRIPTION
Writing the OpenAPI spec now stors the list of its parameters by the name of each parameter. This way the spec becomes more stable when regenerating according to the parameters. Eases the work of the code generators of the spec. I'm looking at you Dart !!